### PR TITLE
Fix upstream bug with coreutils_core crate

### DIFF
--- a/where-rs/Cargo.toml
+++ b/where-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "where-rs"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "A small Rust client for the WHRD/UDP protocol, to access a list of logged in users on multiple systems at once."
 authors = ["Starscouts", "ryze132"]

--- a/whered/Cargo.toml
+++ b/whered/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whered"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "A small Rust server for the WHRD/UDP protocol, to access a list of logged in users on multiple systems at once."
 authors = ["Starscouts", "ryze132"]

--- a/whrd/Cargo.toml
+++ b/whrd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whrd"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "A Rust library to work with the WHRD/UDP protocol, a protocol to access a list of logged in users on multiple systems at once."
 authors = ["Starscouts", "ryze132"]


### PR DESCRIPTION
This patch creates a workaround for a bug in the [coreutils_core](https://crates.io/crates/coreutils_core) library – specifically the `os::utmpx` module – that causes it to show dead (exited abnormally) sessions the same as active sessions, causing whered to produce incorrect output.

This also bumps version from 1.0.0 to 1.1.0.